### PR TITLE
chore: modernize Flask runtime so it runs locally

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,2 @@
+FLASK_APP=app
+FLASK_DEBUG=1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ __pycache__
 python3-virtualenv
 flask.sqlite
 .DS_Store
+.venv/
+.env
+__pycache__/
+*.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-cffi==1.15.0
-click==8.0.1
-cryptography==37.0.2
-Flask==2.0.1
-itsdangerous==2.0.1
-Jinja2==3.0.1
-MarkupSafe==2.0.1
-peewee==3.14.10
-pycparser==2.21
-PyMySQL==1.0.2
-python-dotenv==0.17.1
-Werkzeug==2.0.1
+# Modernized from the MLH template's 2021 pins (Flask 2.0.1) so the app runs
+# on current Python (tested on 3.14). The old Werkzeug/Jinja pins fail to build
+# on 3.12+, which blocks the "run locally" task. peewee/PyMySQL/cffi/cryptography
+# were unused in week 1 and are dropped until a database lands in a later week.
+Flask==3.1.3
+Werkzeug==3.1.8
+Jinja2==3.1.6
+itsdangerous==2.2.0
+click==8.4.1
+MarkupSafe==3.0.3
+blinker==1.9.0
+python-dotenv==1.2.2


### PR DESCRIPTION
Bumps the 2021 pins (Flask 2.0.1 → 3.1) so the app builds on current Python, and adds `.flaskenv`.

Closes #1